### PR TITLE
Lazy Load Images

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig({
       lastmod: new Date(),
     }),
     vercelImage({
-      sizes: [640, 750, 828, 1080, 1200],
+      sizes: [8, 640, 750, 828, 1080, 1200],
       domains: [],
       minimumCacheTTL: 60,
       formats: ['image/avif', 'image/webp'],

--- a/src/components/EmailList.tsx
+++ b/src/components/EmailList.tsx
@@ -14,90 +14,99 @@ export const EmailList = () => {
     if (hasClosedEmailList) {
       return
     }
+    // const timeout = setTimeout(() => {
+    //   setShowEmailUpsell(true)
+    // }, 10000)
     const timeout = setTimeout(() => {
       setShowEmailUpsell(true)
-    }, 10000)
+    }, 1000)
     return () => clearTimeout(timeout)
   }, [hasClosedEmailList])
 
   return (
     <div
-      className="bg-backgroundSecondary p-3 sticky bottom-0 z-20 container"
+      className="p-0 sm:p-2 sticky bottom-0 z-20"
       style={{
-        transform: shouldShowEmailList ? 'scale(1)' : 'scale(0.95)',
+        transform: shouldShowEmailList
+          ? 'scale(1) translateX(0px)'
+          : 'scale(0.95) translateX(calc(min(100%, 500px) * -1))',
         opacity: shouldShowEmailList ? 1 : 0,
-        transition: `all ${shouldShowEmailList ? '0.5s' : '0.2s'} ease-in-out`,
-        borderTopLeftRadius: '32px',
-        borderTopRightRadius: '32px',
+        transition: `transform ${
+          shouldShowEmailList ? '0.2s' : '0.1s'
+        } ease-in-out`,
+        marginTop: '-16px',
+        width: 'min(100%, 500px)',
       }}
     >
-      <div
-        className="py-4"
-        aria-hidden={shouldShowEmailList ? 'false' : 'true'}
-      >
-        <form
-          action="https://buttondown.email/api/emails/embed-subscribe/jcblw"
-          method="post"
-          target="popupwindow"
-          onSubmit={() => {
-            setShowEmailUpsell(false)
-            setEmailListClosed(true)
-            window.open('https://buttondown.email/jcblw', 'popupwindow')
-          }}
-          className="embeddable-buttondown-form border--none"
+      <div className="bg-backgroundSecondary p-0 sm:p-2 rounded-none sm:rounded-md">
+        <div
+          className="p-2 relative"
+          aria-hidden={shouldShowEmailList ? 'false' : 'true'}
         >
-          {shouldShowEmailList && (
-            <div
-              tabIndex={0}
-              className="absolute h3 color-link p-2 cursor-pointer"
-              style={{ right: 0, top: 0 }}
-              onClick={() => {
-                setShowEmailUpsell(false)
-                setEmailListClosed(true)
-              }}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
+          <form
+            action="https://buttondown.email/api/emails/embed-subscribe/jcblw"
+            method="post"
+            target="popupwindow"
+            onSubmit={() => {
+              setShowEmailUpsell(false)
+              setEmailListClosed(true)
+              window.open('https://buttondown.email/jcblw', 'popupwindow')
+            }}
+            className="embeddable-buttondown-form border--none"
+          >
+            {shouldShowEmailList && (
+              <div
+                tabIndex={0}
+                className="absolute color-link p-2 cursor-pointer"
+                style={{ right: 0, top: 0 }}
+                onClick={() => {
                   setShowEmailUpsell(false)
                   setEmailListClosed(true)
-                }
-              }}
-            >
-              <Icon icon="close" width="24" height="24" />
-            </div>
-          )}
-          <h4 className="color-overline font-bold pt-0">
-            Subscribe to my newsletter
-          </h4>
-          <p className="pt-0">
-            I will be sharing out my newest articles, projects, and other
-            thoughts to the email list. Join me in exploring technology and how
-            to build humane tech.
-          </p>
-          <div className="flex flex-row pb-2">
-            <input
-              required
-              type="email"
-              name="email"
-              id="bd-email"
-              placeholder="Your email"
-              className="bg-paragraph flex-1 color-backgroundSecondary rounded-md px-3 py-1 border-none mr-2"
-            />
-            <div className="flex--0">
+                }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    setShowEmailUpsell(false)
+                    setEmailListClosed(true)
+                  }
+                }}
+              >
+                <Icon icon="close" width="24" height="24" />
+              </div>
+            )}
+            <h4 className="color-overline py-2 font-bold pt-0">
+              Subscribe to my newsletter
+            </h4>
+            <p className="pt-0">
+              I will be sharing out my newest articles, projects, and other
+              thoughts to the email list. Join me in exploring technology and
+              how to build humane tech.
+            </p>
+            <div className="flex flex-row pb-2">
               <input
-                type="submit"
-                className="text-bold bg-overline color-backgroundSecondary rounded-md px-3 py-1 border-none"
-                value="Subscribe"
+                required
+                type="email"
+                name="email"
+                id="bd-email"
+                placeholder="Your email"
+                className="bg-paragraph flex-1 color-backgroundSecondary rounded-md px-3 py-1 border-none mr-2"
               />
+              <div className="flex--0">
+                <input
+                  type="submit"
+                  className="text-bold bg-overline color-backgroundSecondary rounded-md px-3 py-1 border-none"
+                  value="Subscribe"
+                />
+              </div>
             </div>
-          </div>
-          <div className="text-right">
-            <small>
-              <a href="https://buttondown.email" target="_blank">
-                Powered by Buttondown.
-              </a>
-            </small>
-          </div>
-        </form>
+            <div className="text-right">
+              <small>
+                <a href="https://buttondown.email" target="_blank">
+                  Powered by Buttondown.
+                </a>
+              </small>
+            </div>
+          </form>
+        </div>
       </div>
     </div>
   )

--- a/src/components/EmailList.tsx
+++ b/src/components/EmailList.tsx
@@ -14,12 +14,9 @@ export const EmailList = () => {
     if (hasClosedEmailList) {
       return
     }
-    // const timeout = setTimeout(() => {
-    //   setShowEmailUpsell(true)
-    // }, 10000)
     const timeout = setTimeout(() => {
       setShowEmailUpsell(true)
-    }, 1000)
+    }, 10000)
     return () => clearTimeout(timeout)
   }, [hasClosedEmailList])
 

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -12,8 +12,8 @@ const isBuild = import.meta.env.MODE === 'production'
 
 export const Img = ({
   src,
-  width,
-  quality,
+  width = 640,
+  quality = 75,
   alt,
   className,
   ...rest

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -63,7 +63,7 @@ export const Img = ({
           src={placeholderURL}
           alt={alt}
           width={`${width}px`}
-          className={`${aspectRatio} blur-lg object-cover ${className}`}
+          className={`${aspectRatio} blur-lg object-cover ${className ?? ''}`}
           {...rest}
         />
       ) : (
@@ -71,7 +71,7 @@ export const Img = ({
           src={optimizedURL}
           alt={alt}
           width={`${width}px`}
-          className={`${aspectRatio} object-cover ${className}`}
+          className={`${aspectRatio} object-cover ${className ?? ''}`}
           {...rest}
         />
       )}

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -6,7 +6,7 @@ export interface Props extends HTMLAttributes<HTMLImageElement> {
   alt: string
   width?: number
   quality?: number
-  aspectRatio?: CSSProperties['aspectRatio']
+  aspectRatio?: 'aspect-video' | 'aspect-auto'
 }
 
 const isBuild = import.meta.env.MODE === 'production'
@@ -17,7 +17,7 @@ export const Img = ({
   quality = 100,
   alt,
   className,
-  aspectRatio = 'auto',
+  aspectRatio = 'aspect-auto',
   ...rest
 }: Props) => {
   const [isLoaded, setIsLoaded] = useState(!isBuild)
@@ -54,16 +54,13 @@ export const Img = ({
   }, [optimizedURL, shouldBlur])
 
   return (
-    <div
-      className={className}
-      style={width ? { width: `${width}px`, aspectRatio } : {}}
-    >
+    <div style={width ? { width: `${width}px` } : {}}>
       {shouldBlur && !isLoaded ? (
         <img
           src={placeholderURL}
           alt={alt}
           width={`${width}px`}
-          className={className}
+          className={`${aspectRatio} object-cover ${className}`}
           {...rest}
         />
       ) : (
@@ -71,7 +68,7 @@ export const Img = ({
           src={optimizedURL}
           alt={alt}
           width={`${width}px`}
-          className={className}
+          className={`${aspectRatio} object-cover ${className}`}
           {...rest}
         />
       )}

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -54,7 +54,10 @@ export const Img = ({
   }, [optimizedURL, shouldBlur])
 
   return (
-    <div style={width ? { width: `${width}px` } : {}}>
+    <div
+      className={`overflow-hidden ${className}`}
+      style={width ? { width: `${width}px` } : {}}
+    >
       {shouldBlur && !isLoaded ? (
         <img
           src={placeholderURL}

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react'
+import type { CSSProperties, HTMLAttributes } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 
 export interface Props extends HTMLAttributes<HTMLImageElement> {
@@ -6,6 +6,7 @@ export interface Props extends HTMLAttributes<HTMLImageElement> {
   alt: string
   width?: number
   quality?: number
+  aspectRatio?: CSSProperties['aspectRatio']
 }
 
 const isBuild = import.meta.env.MODE === 'production'
@@ -13,9 +14,10 @@ const isBuild = import.meta.env.MODE === 'production'
 export const Img = ({
   src,
   width = 640,
-  quality = 75,
+  quality = 100,
   alt,
   className,
+  aspectRatio = 'auto',
   ...rest
 }: Props) => {
   const [isLoaded, setIsLoaded] = useState(!isBuild)
@@ -52,7 +54,10 @@ export const Img = ({
   }, [optimizedURL, shouldBlur])
 
   return (
-    <div className={className} style={width ? { width: `${width}px` } : {}}>
+    <div
+      className={className}
+      style={width ? { width: `${width}px`, aspectRatio } : {}}
+    >
       {shouldBlur && !isLoaded ? (
         <img
           src={placeholderURL}

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -1,0 +1,70 @@
+import type { HTMLAttributes } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+
+export interface Props extends HTMLAttributes<HTMLImageElement> {
+  src: string
+  alt: string
+  width?: number
+  quality?: number
+}
+
+const isBuild = import.meta.env.MODE === 'production'
+
+export const Img = ({
+  src,
+  width,
+  quality,
+  alt,
+  className,
+  ...rest
+}: Props) => {
+  const [isLoaded, setIsLoaded] = useState(!isBuild)
+  const { optimizedURL, shouldBlur, placeholderURL } = useMemo(() => {
+    if (isBuild) {
+      return {
+        shouldBlur: true,
+        placeholderURL: `/_vercel/image?url=${encodeURIComponent(
+          src
+        )}&w=8&q=50`,
+      }
+    } else {
+      return {
+        shouldBlur: false,
+        placeholderURL: '',
+        optimizedURL: src,
+      }
+    }
+  }, [width, quality, src])
+
+  useEffect(() => {
+    if (shouldBlur && !isLoaded) {
+      const img = new Image()
+      img.src = src
+      img.onload = () => {
+        setIsLoaded(true)
+      }
+    }
+  }, [src, shouldBlur])
+
+  return (
+    <div className={className} style={width ? { width: `${width}px` } : {}}>
+      {shouldBlur && !isLoaded ? (
+        <img
+          src={placeholderURL}
+          alt={alt}
+          width={`${width}px`}
+          className={className}
+          {...rest}
+        />
+      ) : (
+        <img
+          src={optimizedURL}
+          alt={alt}
+          width={`${width}px`}
+          className={className}
+          {...rest}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -60,7 +60,7 @@ export const Img = ({
           src={placeholderURL}
           alt={alt}
           width={`${width}px`}
-          className={`${aspectRatio} object-cover ${className}`}
+          className={`${aspectRatio} blur-lg object-cover ${className}`}
           {...rest}
         />
       ) : (

--- a/src/components/Img.tsx
+++ b/src/components/Img.tsx
@@ -26,6 +26,9 @@ export const Img = ({
         placeholderURL: `/_vercel/image?url=${encodeURIComponent(
           src
         )}&w=8&q=50`,
+        optimizedURL: `/_vercel/image?url=${encodeURIComponent(
+          src
+        )}&w=${width}&q=${quality}`,
       }
     } else {
       return {
@@ -38,13 +41,15 @@ export const Img = ({
 
   useEffect(() => {
     if (shouldBlur && !isLoaded) {
+      console.log('loading image', optimizedURL)
       const img = new Image()
-      img.src = src
+      img.src = optimizedURL
       img.onload = () => {
+        console.log('img loading', optimizedURL)
         setIsLoaded(true)
       }
     }
-  }, [src, shouldBlur])
+  }, [optimizedURL, shouldBlur])
 
   return (
     <div className={className} style={width ? { width: `${width}px` } : {}}>

--- a/src/components/MarkdownImg.astro
+++ b/src/components/MarkdownImg.astro
@@ -12,4 +12,4 @@ const {className, ...props} = Astro.props
 
 
 ---
-<Img client:visible className={`rounded-sm ${className}`} {...props}  />
+<Img client:visible className={`rounded-sm ${className ?? ''}`} {...props} width={828} />

--- a/src/components/MarkdownImg.astro
+++ b/src/components/MarkdownImg.astro
@@ -12,4 +12,4 @@ const {className, ...props} = Astro.props
 
 
 ---
-<Img client:visible className={`rounded-xs max-w-full ${className ?? ''}`} {...props} width={828} />
+<Img client:idle className={`rounded-xs max-w-full ${className ?? ''}`} {...props} width={828} />

--- a/src/components/MarkdownImg.astro
+++ b/src/components/MarkdownImg.astro
@@ -12,4 +12,4 @@ const {className, ...props} = Astro.props
 
 
 ---
-<Img client:visible className={`rounded-sm ${className ?? ''}`} {...props} width={828} />
+<Img client:visible className={`rounded-xs max-w-full ${className ?? ''}`} {...props} width={828} />

--- a/src/components/MarkdownImg.astro
+++ b/src/components/MarkdownImg.astro
@@ -1,0 +1,15 @@
+---
+import type { Props  as ImgProps } from "./Img";
+import { Img } from "./Img";
+
+export interface Props extends ImgProps {
+  alt: string;
+  width?: number;
+  height?: number;
+}
+
+const {className, ...props} = Astro.props
+
+
+---
+<Img client:visible className={`rounded-sm ${className}`} {...props}  />

--- a/src/components/MarkdownImg.astro
+++ b/src/components/MarkdownImg.astro
@@ -12,4 +12,4 @@ const {className, ...props} = Astro.props
 
 
 ---
-<Img client:idle className={`rounded-xs max-w-full ${className ?? ''}`} {...props} width={828} />
+<Img client:load className={`rounded-xs max-w-full ${className ?? ''}`} {...props} width={828} />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -65,7 +65,7 @@ const microdata = {
 		<Header />
 		<main class="relative z-10">
 			<div class="flex items-center justify-center px-0 sm:px-1">
-				{heroImage && <Img client:visible src={heroImage} width={1080} alt={title} className="hero-image rounded-none sm:rounded-md"/>}
+				{heroImage && <Img client:visible src={heroImage} aspectRatio="16 / 9" width={1080} alt={title} className="hero-image rounded-none sm:rounded-md"/>}
 			</div>
 			<TableOfContents links={headings} />
 			<section class="container">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -6,9 +6,8 @@ import Footer from '../components/Footer.astro';
 import { siteMetadata } from '../consts';
 import Time from '../components/Time.astro';
 import TableOfContents from '../components/TableOfContents.astro';
-import VercelImage from 'astro-vercel-image/VercelImage.astro';
 import { Comments } from '../components/Comments';
-import type { Img } from '../components/Img';
+import { Img } from '../components/Img';
 
 type BlogData = CollectionEntry<'blog'>['data'];
 

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -65,7 +65,7 @@ const microdata = {
 		<Header />
 		<main class="relative z-10">
 			<div class="flex items-center justify-center px-0 sm:px-1">
-				{heroImage && <Img src={heroImage} width={1080} alt={title} className="hero-image rounded-none sm:rounded-md"/>}
+				{heroImage && <Img client:visible src={heroImage} width={1080} alt={title} className="hero-image rounded-none sm:rounded-md"/>}
 			</div>
 			<TableOfContents links={headings} />
 			<section class="container">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -65,7 +65,7 @@ const microdata = {
 		<Header />
 		<main class="relative z-10">
 			<div class="flex items-center justify-center px-0 sm:px-1">
-				{heroImage && <Img client:visible src={heroImage} aspectRatio="16 / 9" width={1080} alt={title} className="hero-image rounded-none sm:rounded-md"/>}
+				{heroImage && <Img client:visible src={heroImage} aspectRatio="aspect-video" width={1080} alt={title} className="hero-image rounded-none sm:rounded-md"/>}
 			</div>
 			<TableOfContents links={headings} />
 			<section class="container">

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -8,6 +8,7 @@ import Time from '../components/Time.astro';
 import TableOfContents from '../components/TableOfContents.astro';
 import VercelImage from 'astro-vercel-image/VercelImage.astro';
 import { Comments } from '../components/Comments';
+import type { Img } from '../components/Img';
 
 type BlogData = CollectionEntry<'blog'>['data'];
 
@@ -65,7 +66,7 @@ const microdata = {
 		<Header />
 		<main class="relative z-10">
 			<div class="flex items-center justify-center px-0 sm:px-1">
-				{heroImage && <VercelImage src={heroImage} width={1080} alt={title} class="hero-image rounded-none sm:rounded-md"/>}
+				{heroImage && <Img src={heroImage} width={1080} alt={title} className="hero-image rounded-none sm:rounded-md"/>}
 			</div>
 			<TableOfContents links={headings} />
 			<section class="container">

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -1,7 +1,7 @@
 ---
 import { CollectionEntry, getCollection } from 'astro:content';
+import MarkdownImg from '../components/MarkdownImg.astro';
 import BlogPost from '../layouts/BlogPost.astro';
-import VercelImage from 'astro-vercel-image/VercelImage.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -24,5 +24,5 @@ const formattedHeadings = headings.map(heading => ({
 
 <BlogPost {...post.data} minutesRead={minutesRead} headings={formattedHeadings} slug={post.slug}>
 	<!-- <pre><code>{JSON.stringify(post, null, 2)}</code></pre> -->
-	<Content components={{ img: VercelImage }} />
+	<Content components={{ img: MarkdownImg }} />
 </BlogPost>


### PR DESCRIPTION
This PR adds lazy loading images to blog posts. This will load tiny images from Vercel before loading them in high-quality versions of the image. 

#### TODO

- [ ] Remove from the hero image
- [ ] Get client rendering working for the images in markdown
- [ ] Evaluate if this makes sense to push
 