### PR TITLE
switch email list from buttondown to substack

### DIFF
--- a/src/components/EmailList.tsx
+++ b/src/components/EmailList.tsx
@@ -1,6 +1,9 @@
 import { useEffect, useState } from 'react'
 import { useLocalStorage } from '../utils/useLocalStorage'
 import { Icon } from './Icon'
+import { siteMetadata } from '../consts'
+
+const SUBSCRIBE_URL = `${siteMetadata.substack}/subscribe?utm_source=website&utm_medium=popup`
 
 export const EmailList = () => {
   const [showEmailUpsell, setShowEmailUpsell] = useState(false)
@@ -19,6 +22,11 @@ export const EmailList = () => {
     }, 10000)
     return () => clearTimeout(timeout)
   }, [hasClosedEmailList])
+
+  const dismiss = () => {
+    setShowEmailUpsell(false)
+    setEmailListClosed(true)
+  }
 
   return (
     <div
@@ -40,69 +48,41 @@ export const EmailList = () => {
           className="relative p-2"
           aria-hidden={shouldShowEmailList ? 'false' : 'true'}
         >
-          <form
-            action="https://buttondown.email/api/emails/embed-subscribe/jcblw"
-            method="post"
-            target="popupwindow"
-            onSubmit={() => {
-              setShowEmailUpsell(false)
-              setEmailListClosed(true)
-              window.open('https://buttondown.email/jcblw', 'popupwindow')
-            }}
-            className="embeddable-buttondown-form border--none"
-          >
-            {shouldShowEmailList && (
-              <div
-                tabIndex={0}
-                className="color-link absolute cursor-pointer p-2"
-                style={{ right: 0, top: 0 }}
-                onClick={() => {
-                  setShowEmailUpsell(false)
-                  setEmailListClosed(true)
-                }}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter' || event.key === ' ') {
-                    setShowEmailUpsell(false)
-                    setEmailListClosed(true)
-                  }
-                }}
-              >
-                <Icon icon="close" width="24" height="24" />
-              </div>
-            )}
-            <h4 className="color-overline py-2 pt-0 font-medium">
-              Subscribe to my newsletter
-            </h4>
-            <p className="pt-0">
-              I will be sharing out my newest articles, projects, and other
-              thoughts to the email list. Join me in exploring technology and
-              how to build humane tech.
-            </p>
-            <div className="flex flex-row pb-2">
-              <input
-                required
-                type="email"
-                name="email"
-                id="bd-email"
-                placeholder="Your email"
-                className="bg-paragraph color-backgroundSecondary mr-2 flex-1 rounded-md border-none px-3 py-1"
-              />
-              <div className="flex--0">
-                <input
-                  type="submit"
-                  className="text-bold bg-overline color-backgroundSecondary rounded-md border-none px-3 py-1"
-                  value="Subscribe"
-                />
-              </div>
+          {shouldShowEmailList && (
+            <div
+              tabIndex={0}
+              role="button"
+              aria-label="Dismiss newsletter prompt"
+              className="color-link absolute cursor-pointer p-2"
+              style={{ right: 0, top: 0 }}
+              onClick={dismiss}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                  dismiss()
+                }
+              }}
+            >
+              <Icon icon="close" width="24" height="24" />
             </div>
-            <div className="text-right">
-              <small>
-                <a href="https://buttondown.email" target="_blank">
-                  Powered by Buttondown.
-                </a>
-              </small>
-            </div>
-          </form>
+          )}
+          <h4 className="color-overline py-2 pt-0 font-medium">
+            Subscribe to my newsletter
+          </h4>
+          <p className="pt-0">
+            I share new articles, projects, and thoughts on building humane
+            technology. Free, no spam, unsubscribe anytime.
+          </p>
+          <div className="flex flex-row items-center pb-2">
+            <a
+              href={SUBSCRIBE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={dismiss}
+              className="text-bold bg-overline color-backgroundSecondary rounded-md border-none px-3 py-1 no-underline"
+            >
+              Subscribe on Substack
+            </a>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,5 +1,6 @@
 ---
 import { EmailList } from './EmailList'
+import { siteMetadata } from '../consts'
 
 const today = new Date()
 const year = today.getFullYear()
@@ -8,7 +9,7 @@ const year = today.getFullYear()
 <footer class="container relative z-10">
   <hr />
   <p class="pb-0">
-    Join my <a href="https://buttondown.email/jcblw?tag=website">email list</a>
+    Join my <a href={`${siteMetadata.substack}?utm_source=website&utm_medium=footer`}>Substack newsletter</a>
   </p>
   <p class="pb-6 pt-0">&copy; {year} Jacob Lowe. All rights reserved.</p>
 </footer>

--- a/src/components/SubscribeCTA.astro
+++ b/src/components/SubscribeCTA.astro
@@ -1,0 +1,54 @@
+---
+import { siteMetadata } from '../consts'
+
+interface Props {
+  source?: string
+  heading?: string
+  body?: string
+  cta?: string
+}
+
+const {
+  source = 'post-footer',
+  heading = 'Enjoyed this?',
+  body = 'Get new articles, projects, and thoughts on humane technology in your inbox. Free, no spam.',
+  cta = 'Subscribe on Substack',
+} = Astro.props
+
+const href = `${siteMetadata.substack}/subscribe?utm_source=website&utm_medium=${source}`
+---
+
+<aside class="subscribe-cta">
+  <div class="subscribe-cta__inner">
+    <h4 class="color-overline pb-1 pt-0 font-medium">{heading}</h4>
+    <p class="pb-3 pt-0">{body}</p>
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="subscribe-cta__button"
+    >
+      {cta}
+    </a>
+  </div>
+</aside>
+
+<style>
+  .subscribe-cta {
+    margin: 2rem 0;
+  }
+  .subscribe-cta__inner {
+    background: var(--color-backgroundSecondary);
+    border-radius: 12px;
+    padding: 1.25rem 1.5rem;
+  }
+  .subscribe-cta__button {
+    display: inline-block;
+    background: var(--color-overline);
+    color: var(--color-backgroundSecondary);
+    border-radius: 8px;
+    padding: 0.4rem 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+  }
+</style>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,6 +4,7 @@ export const siteMetadata = {
   siteUrl: 'https://jcbl.ws',
   github: 'https://github.com/jcblw',
   linkedin: 'https://www.linkedin.com/in/%F0%9F%8C%BF-jacob-lowe-50a49126/',
+  substack: 'https://mujojcblw.substack.com',
   author: 'Jacob Lowe',
   aboutAuthor: 'I am a founder of Mujō.',
   avatar: 'https://avatars1.githubusercontent.com/u/578259?s=460&v=4',

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -13,6 +13,7 @@ import RelatedPosts from '../components/RelatedPosts.astro'
 import { getSimilarPosts } from '../utils/sql'
 import { LikeButton } from '../components/LikeButton'
 import GrainOverlay from '../components/GrainOverlay.astro'
+import SubscribeCTA from '../components/SubscribeCTA.astro'
 import 'dotenv/config'
 
 type BlogData = CollectionEntry<'blog'>['data']
@@ -179,6 +180,9 @@ const microdata = {
         <hr />
         <slot />
       </article>
+      <section class="container">
+        <SubscribeCTA source="post-footer" />
+      </section>
       {
         relatedPosts && relatedPosts.length > 0 && (
           <>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,7 @@ import { getProfileInfo, getReadme } from '../utils/github'
 import FeaturedProjects from '../components/FeaturedProjects.astro'
 import Author from '../components/Author.astro'
 import GrainOverlay from '../components/GrainOverlay.astro'
+import SubscribeCTA from '../components/SubscribeCTA.astro'
 
 const posts = (await getCollection('blog'))
   .filter((post) => !post.data.status || post.data.status !== 'draft')
@@ -60,6 +61,13 @@ const pinnedItems = profile.pinnedItems.nodes
             ))
           }
         </ul>
+      </section>
+      <section>
+        <SubscribeCTA
+          source="homepage"
+          heading="Stay in the loop"
+          body="I send new posts, projects, and thoughts on humane technology straight to your inbox."
+        />
       </section>
       <section>
         <FeaturedProjects projects={pinnedItems} />


### PR DESCRIPTION
## Summary
- Replaces Buttondown embed form with link-outs to `mujojcblw.substack.com`
- Adds reusable `SubscribeCTA` component surfaced in the popup, footer, end-of-post CTA, and homepage
- Threads `siteMetadata.substack` + per-surface `utm_medium` so signup source is trackable in Substack

## Test plan
- [ ] `pnpm astro build` — passes locally
- [ ] Homepage renders the CTA between Featured Posts and Featured Projects
- [ ] Any blog post shows the CTA below the article, above Related Posts
- [ ] Footer link opens `mujojcblw.substack.com` with `utm_medium=footer`
- [ ] After ~10s on a blog post, popup slides in; clicking "Subscribe on Substack" opens Substack subscribe page and dismisses the popup (localStorage `__elc`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)