### PR TITLE
Revert newsletter from Substack back to Buttondown

### DIFF
--- a/src/components/EmailList.tsx
+++ b/src/components/EmailList.tsx
@@ -3,8 +3,6 @@ import { useLocalStorage } from '../utils/useLocalStorage'
 import { Icon } from './Icon'
 import { siteMetadata } from '../consts'
 
-const SUBSCRIBE_URL = `${siteMetadata.substack}/subscribe?utm_source=website&utm_medium=popup`
-
 export const EmailList = () => {
   const [showEmailUpsell, setShowEmailUpsell] = useState(false)
   const [hasClosedEmailList, setEmailListClosed] = useLocalStorage(
@@ -48,41 +46,54 @@ export const EmailList = () => {
           className="relative p-2"
           aria-hidden={shouldShowEmailList ? 'false' : 'true'}
         >
-          {shouldShowEmailList && (
-            <div
-              tabIndex={0}
-              role="button"
-              aria-label="Dismiss newsletter prompt"
-              className="color-link absolute cursor-pointer p-2"
-              style={{ right: 0, top: 0 }}
-              onClick={dismiss}
-              onKeyDown={(event) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                  dismiss()
-                }
-              }}
-            >
-              <Icon icon="close" width="24" height="24" />
+          <form
+            action={siteMetadata.newsletterSubscribeEndpoint}
+            method="post"
+            target="_blank"
+            onSubmit={dismiss}
+          >
+            {shouldShowEmailList && (
+              <div
+                tabIndex={0}
+                role="button"
+                aria-label="Dismiss newsletter prompt"
+                className="color-link absolute cursor-pointer p-2"
+                style={{ right: 0, top: 0 }}
+                onClick={dismiss}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    dismiss()
+                  }
+                }}
+              >
+                <Icon icon="close" width="24" height="24" />
+              </div>
+            )}
+            <h4 className="color-overline py-2 pt-0 font-medium">
+              Subscribe to my newsletter
+            </h4>
+            <p className="pt-0">
+              I share new articles, projects, and thoughts on building humane
+              technology. Free, no spam, unsubscribe anytime.
+            </p>
+            <input type="hidden" name="tag" value="popup" />
+            <div className="flex flex-row pb-2">
+              <input
+                required
+                type="email"
+                name="email"
+                placeholder="Your email"
+                className="bg-paragraph color-backgroundSecondary mr-2 flex-1 rounded-md border-none px-3 py-1"
+              />
+              <div className="flex--0">
+                <input
+                  type="submit"
+                  className="text-bold bg-overline color-backgroundSecondary cursor-pointer rounded-md border-none px-3 py-1"
+                  value="Subscribe"
+                />
+              </div>
             </div>
-          )}
-          <h4 className="color-overline py-2 pt-0 font-medium">
-            Subscribe to my newsletter
-          </h4>
-          <p className="pt-0">
-            I share new articles, projects, and thoughts on building humane
-            technology. Free, no spam, unsubscribe anytime.
-          </p>
-          <div className="flex flex-row items-center pb-2">
-            <a
-              href={SUBSCRIBE_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={dismiss}
-              className="text-bold bg-overline color-backgroundSecondary rounded-md border-none px-3 py-1 no-underline"
-            >
-              Subscribe on Substack
-            </a>
-          </div>
+          </form>
         </div>
       </div>
     </div>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -9,7 +9,7 @@ const year = today.getFullYear()
 <footer class="container relative z-10">
   <hr />
   <p class="pb-0">
-    Join my <a href={`${siteMetadata.substack}?utm_source=website&utm_medium=footer`}>Substack newsletter</a>
+    Join my <a href={`${siteMetadata.newsletter}?tag=footer`}>email list</a>
   </p>
   <p class="pb-6 pt-0">&copy; {year} Jacob Lowe. All rights reserved.</p>
 </footer>

--- a/src/components/SubscribeCTA.astro
+++ b/src/components/SubscribeCTA.astro
@@ -12,24 +12,30 @@ const {
   source = 'post-footer',
   heading = 'Enjoyed this?',
   body = 'Get new articles, projects, and thoughts on humane technology in your inbox. Free, no spam.',
-  cta = 'Subscribe on Substack',
+  cta = 'Subscribe',
 } = Astro.props
-
-const href = `${siteMetadata.substack}/subscribe?utm_source=website&utm_medium=${source}`
 ---
 
 <aside class="subscribe-cta">
   <div class="subscribe-cta__inner">
     <h4 class="color-overline pb-1 pt-0 font-medium">{heading}</h4>
     <p class="pb-3 pt-0">{body}</p>
-    <a
-      href={href}
+    <form
+      action={siteMetadata.newsletterSubscribeEndpoint}
+      method="post"
       target="_blank"
-      rel="noopener noreferrer"
-      class="subscribe-cta__button"
+      class="subscribe-cta__form"
     >
-      {cta}
-    </a>
+      <input type="hidden" name="tag" value={source} />
+      <input
+        required
+        type="email"
+        name="email"
+        placeholder="Your email"
+        class="subscribe-cta__input bg-paragraph color-backgroundSecondary rounded-md border-none px-3 py-1"
+      />
+      <button type="submit" class="subscribe-cta__button">{cta}</button>
+    </form>
   </div>
 </aside>
 
@@ -42,13 +48,22 @@ const href = `${siteMetadata.substack}/subscribe?utm_source=website&utm_medium=$
     border-radius: 12px;
     padding: 1.25rem 1.5rem;
   }
+  .subscribe-cta__form {
+    display: flex;
+    flex-direction: row;
+    gap: 0.5rem;
+  }
+  .subscribe-cta__input {
+    flex: 1;
+    min-width: 0;
+  }
   .subscribe-cta__button {
-    display: inline-block;
     background: var(--color-overline);
     color: var(--color-backgroundSecondary);
+    border: none;
     border-radius: 8px;
     padding: 0.4rem 0.9rem;
     font-weight: 600;
-    text-decoration: none;
+    cursor: pointer;
   }
 </style>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -4,7 +4,9 @@ export const siteMetadata = {
   siteUrl: 'https://jcbl.ws',
   github: 'https://github.com/jcblw',
   linkedin: 'https://www.linkedin.com/in/%F0%9F%8C%BF-jacob-lowe-50a49126/',
-  substack: 'https://mujojcblw.substack.com',
+  newsletter: 'https://buttondown.com/jcblw',
+  newsletterSubscribeEndpoint:
+    'https://buttondown.com/api/emails/embed-subscribe/jcblw',
   author: 'Jacob Lowe',
   aboutAuthor: 'I am a founder of Mujō.',
   avatar: 'https://avatars1.githubusercontent.com/u/578259?s=460&v=4',


### PR DESCRIPTION
## Summary
- Replaces all Substack link-outs with native Buttondown embed forms (popup, end-of-post CTA, homepage CTA) posting to the `jcblw` Buttondown endpoint with per-surface `tag` inputs for source tracking
- Footer links to the Buttondown page
- `siteMetadata.newsletter` / `newsletterSubscribeEndpoint` are now the canonical config

## Before merging (account side, needs Jacob)
- [ ] Verify the `jcblw` Buttondown account is still active (forms 404 otherwise)
- [ ] Export subscribers from Substack (Settings → Exports) and import into Buttondown so signups from the last ~2 weeks aren't lost
- [ ] Optional: disable/park the Substack publication after import

## Test plan
- [x] `pnpm astro build` passes, zero `substack` references left in src
- [ ] Submit a test email through the popup form on preview and confirm it lands in Buttondown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC5dV7rN9giGQyM9SuQJGa