### PR TITLE
Override path-to-regexp to patched 6.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
       "brace-expansion": "^5.0.6",
       "tar": "^7.5.16",
       "@babel/core": "^7.29.6",
-      "js-yaml": "^4.2.0"
+      "js-yaml": "^4.2.0",
+      "path-to-regexp": "^6.3.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   tar: ^7.5.16
   '@babel/core': ^7.29.6
   js-yaml: ^4.2.0
+  path-to-regexp: ^6.3.0
 
 dependencies:
   '@ai-sdk/openai':
@@ -1974,7 +1975,7 @@ packages:
   /@vercel/routing-utils@5.3.3:
     resolution: {integrity: sha512-KYm2sLNUD48gDScv8ob4ejc3Gww2jcJyW80hTdYlenAPz/5BQar1Gyh38xrUuZ532TUwSb5mV1uRbAuiykq0EQ==}
     dependencies:
-      path-to-regexp: 6.1.0
+      path-to-regexp: 6.3.0
       path-to-regexp-updated: /path-to-regexp@6.3.0
     optionalDependencies:
       ajv: 6.15.0
@@ -3945,10 +3946,6 @@ packages:
     dependencies:
       lru-cache: 11.2.7
       minipass: 7.1.3
-    dev: false
-
-  /path-to-regexp@6.1.0:
-    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
     dev: false
 
   /path-to-regexp@6.3.0:


### PR DESCRIPTION
Clears the last open Dependabot alert (#148, high): path-to-regexp ReDoS. `@vercel/routing-utils` (via `@astrojs/vercel`) pins vulnerable 6.1.0 next to an aliased patched 6.3.0 — this override forces 6.3.0 everywhere. Same-major bump; build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WC5dV7rN9giGQyM9SuQJGa